### PR TITLE
Remove strong-strong reference cycles

### DIFF
--- a/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardInteractor.swift
+++ b/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardInteractor.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class TouristDashboardInteractor: InteractorProtocol {
 
-    var presenter: TouristDashboardPresenter!
+    weak var presenter: TouristDashboardPresenter!
 
     let bookingsRepository: BookingRepositoryProtocol
     let userState: UserStateProtocol!

--- a/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardRouter.swift
+++ b/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardRouter.swift
@@ -7,5 +7,5 @@
 
 class TouristDashboardRouter: RouterProtocol {
 
-    var presenter: TouristDashboardPresenter!
+    weak var presenter: TouristDashboardPresenter!
 }

--- a/Challo/Challo/Modules/Map/MapInteractor.swift
+++ b/Challo/Challo/Modules/Map/MapInteractor.swift
@@ -6,7 +6,7 @@
 //
 
 class MapInteractor: InteractorProtocol {
-    var presenter: MapPresenter!
+    weak var presenter: MapPresenter!
     var mapStore: MapStore
     var placesAPI: PlacesAPIProtocol
     

--- a/Challo/Challo/Modules/Settings/SettingsInteractor.swift
+++ b/Challo/Challo/Modules/Settings/SettingsInteractor.swift
@@ -6,7 +6,7 @@
 //
 
 class SettingsInteractor: InteractorProtocol {
-    var presenter: SettingsPresenter!
+    weak var presenter: SettingsPresenter!
     private weak var userState: UserStateProtocol!
 
     init(userState: UserStateProtocol) {


### PR DESCRIPTION
Presenters hold strong references to Interactors and Routers, Interactors and Routers hold weak references back

Do we actually need to specify weak/unowned references to UserState? UserState does not hold any references to any module.