### PR TITLE
Cleanup weak ref

### DIFF
--- a/Challo/Challo/Modules/Dashboard/GuideDashboard/GuideDashboardInteractor.swift
+++ b/Challo/Challo/Modules/Dashboard/GuideDashboard/GuideDashboardInteractor.swift
@@ -12,7 +12,7 @@ class GuideDashboardInteractor: InteractorProtocol {
     weak var presenter: GuideDashboardPresenter!
 
     let bookingRepository: BookingRepositoryProtocol
-    let userState: UserStateProtocol!
+    let userState: UserStateProtocol
 
     init(userState: UserStateProtocol, bookingRepository: BookingRepositoryProtocol) {
         self.bookingRepository = bookingRepository

--- a/Challo/Challo/Modules/Dashboard/GuideDashboard/GuideDashboardModule.swift
+++ b/Challo/Challo/Modules/Dashboard/GuideDashboard/GuideDashboardModule.swift
@@ -18,9 +18,6 @@ final class GuideDashboardModule: ViperModuleProtocol {
     }
 
     func assemble() -> (view: AnyView, presenter: GuideDashboardPresenter) {
-        guard let userState = userState else {
-            fatalError("userState must not be nil")
-        }
         let presenter = GuideDashboardPresenter(userState: userState)
         let interactor = GuideDashboardInteractor(userState: userState, bookingRepository: bookingRepository)
         let router = GuideDashboardRouter()

--- a/Challo/Challo/Modules/Dashboard/GuideDashboard/GuideDashboardModule.swift
+++ b/Challo/Challo/Modules/Dashboard/GuideDashboard/GuideDashboardModule.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 final class GuideDashboardModule: ViperModuleProtocol {
 
-    weak var userState: UserStateProtocol?
+    let userState: UserStateProtocol
     let bookingRepository: BookingRepositoryProtocol
 
     init(userState: UserStateProtocol, bookingRepository: BookingRepositoryProtocol) {

--- a/Challo/Challo/Modules/Dashboard/GuideDashboard/GuideDashboardPresenter.swift
+++ b/Challo/Challo/Modules/Dashboard/GuideDashboard/GuideDashboardPresenter.swift
@@ -18,7 +18,7 @@ class GuideDashboardPresenter: PresenterProtocol {
         }
     }
 
-    unowned let userState: UserStateProtocol!
+    let userState: UserStateProtocol
 
     @Published var name: String
     @Published var loading: Bool = true

--- a/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardInteractor.swift
+++ b/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardInteractor.swift
@@ -12,7 +12,7 @@ class TouristDashboardInteractor: InteractorProtocol {
     weak var presenter: TouristDashboardPresenter!
 
     let bookingsRepository: BookingRepositoryProtocol
-    let userState: UserStateProtocol!
+    let userState: UserStateProtocol
 
     init(bookingsRepository: BookingRepositoryProtocol, userState: UserStateProtocol) {
         self.bookingsRepository = bookingsRepository

--- a/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardModule.swift
+++ b/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardModule.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 final class TouristDashboardModule: ViperModuleProtocol {
 
-    weak var userState: UserStateProtocol?
+    let userState: UserStateProtocol
     let bookingsRepository: BookingRepositoryProtocol
     let sendMessageToGuide: ((_ guideEmail: String, _ guideId: UUID, _ messageText: String) -> Void)
     

--- a/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardModule.swift
+++ b/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardModule.swift
@@ -21,9 +21,6 @@ final class TouristDashboardModule: ViperModuleProtocol {
     }
 
     func assemble() -> (view: AnyView, presenter: TouristDashboardPresenter) {
-        guard let userState = userState else {
-            fatalError("userState is nil in TouristDashboardModule")
-        }
         let interactor = TouristDashboardInteractor(bookingsRepository: bookingsRepository, userState: userState)
         let router = TouristDashboardRouter()
         let presenter = TouristDashboardPresenter(userState: userState, sendMessageToGuide: sendMessageToGuide)

--- a/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardPresenter.swift
+++ b/Challo/Challo/Modules/Dashboard/TouristDashboard/TouristDashboardPresenter.swift
@@ -11,7 +11,7 @@ class TouristDashboardPresenter: PresenterProtocol {
     
     var router: TouristDashboardRouter?
     var interactor: TouristDashboardInteractor!
-    unowned let userState: UserStateProtocol!
+    let userState: UserStateProtocol
 
     let sendMessageToGuide: ((_ guideEmail: String, _ guideId: UUID, _ messageText: String) -> Void)
     

--- a/Challo/Challo/Modules/LoginRegister/Login/GuideLogin/GuideLoginModule.swift
+++ b/Challo/Challo/Modules/LoginRegister/Login/GuideLogin/GuideLoginModule.swift
@@ -9,17 +9,13 @@ import SwiftUI
 
 final class GuideLoginModule: ViperModuleProtocol {
 
-    weak var userState: UserStateProtocol?
+    let userState: UserStateProtocol
     
     init(userState: UserStateProtocol) {
         self.userState = userState
     }
     
     func assemble() -> (view: AnyView, presenter: GuideLoginPresenter) {
-        guard let userState = userState else {
-            fatalError("userState is nil in GuideLoginModule")
-        }
-        
         let certManager = CertificateManager(userState: userState)
         let interactor = GuideLoginInteractor(certificateManager: certManager)
         let presenter = GuideLoginPresenter()

--- a/Challo/Challo/Modules/LoginRegister/Login/TouristLogin/TouristLoginModule.swift
+++ b/Challo/Challo/Modules/LoginRegister/Login/TouristLogin/TouristLoginModule.swift
@@ -15,10 +15,6 @@ final class TouristLoginModule: ViperModuleProtocol {
     }
     
     func assemble() -> (view: AnyView, presenter: TouristLoginPresenter) {
-        guard let userState = userState else {
-            fatalError("userState is nil in TouristLoginModule")
-        }
-
         let certManager = CertificateManager(userState: userState)
         let interactor = TouristLoginInteractor(certificateManager: certManager)
         let presenter = TouristLoginPresenter()

--- a/Challo/Challo/Modules/LoginRegister/Login/TouristLogin/TouristLoginModule.swift
+++ b/Challo/Challo/Modules/LoginRegister/Login/TouristLogin/TouristLoginModule.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 final class TouristLoginModule: ViperModuleProtocol {
 
-    weak var userState: UserStateProtocol?
+    let userState: UserStateProtocol
     
     init(userState: UserStateProtocol) {
         self.userState = userState

--- a/Challo/Challo/Modules/LoginRegister/Register/GuideRegister/GuideRegisterModule.swift
+++ b/Challo/Challo/Modules/LoginRegister/Register/GuideRegister/GuideRegisterModule.swift
@@ -16,10 +16,6 @@ class GuideRegisterModule: ViperModuleProtocol {
     }
     
     func assemble() -> (view: AnyView, presenter: GuideRegisterPresenter) {
-        guard let userState = userState else {
-            fatalError("userState is nil in GuideRegisterModule")
-        }
-        
         let certManager = CertificateManager(userState: userState)
         let interactor = GuideRegisterInteractor(certificateManager: certManager)
         let presenter = GuideRegisterPresenter()

--- a/Challo/Challo/Modules/LoginRegister/Register/GuideRegister/GuideRegisterModule.swift
+++ b/Challo/Challo/Modules/LoginRegister/Register/GuideRegister/GuideRegisterModule.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 class GuideRegisterModule: ViperModuleProtocol {
 
-    weak var userState: UserStateProtocol?
+    let userState: UserStateProtocol
     
     init(userState: UserStateProtocol) {
         self.userState = userState

--- a/Challo/Challo/Modules/LoginRegister/Register/TouristRegister/TouristRegisterModule.swift
+++ b/Challo/Challo/Modules/LoginRegister/Register/TouristRegister/TouristRegisterModule.swift
@@ -9,17 +9,13 @@ import SwiftUI
 
 final class TouristRegisterModule: ViperModuleProtocol {
 
-    weak var userState: UserStateProtocol?
+    let userState: UserStateProtocol
     
     init(userState: UserStateProtocol) {
         self.userState = userState
     }
 
     func assemble() -> (view: AnyView, presenter: TouristRegisterPresenter) {
-        guard let userState = userState else {
-            fatalError("userState is nil in TouristRegisterModule")
-        }
-        
         let certManager = CertificateManager(userState: userState)
         let interactor = TouristRegisterInteractor(certificateManager: certManager)
         let presenter = TouristRegisterPresenter()

--- a/Challo/Challo/Modules/MainContainer/MainContainerInteractor.swift
+++ b/Challo/Challo/Modules/MainContainer/MainContainerInteractor.swift
@@ -8,7 +8,7 @@
 class MainContainerInteractor: InteractorProtocol {
 
     weak var presenter: MainContainerPresenter!
-    let userState: UserStateProtocol!
+    let userState: UserStateProtocol
 
     init(userState: UserStateProtocol) {
         self.userState = userState

--- a/Challo/Challo/Modules/MainContainer/MainContainerModule.swift
+++ b/Challo/Challo/Modules/MainContainer/MainContainerModule.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 class MainContainerModule: ViperModuleProtocol {
 
-    weak var userState: UserStateProtocol?
+    let userState: UserStateProtocol
     
     init(userState: UserStateProtocol) {
         self.userState = userState

--- a/Challo/Challo/Modules/MainContainer/MainContainerModule.swift
+++ b/Challo/Challo/Modules/MainContainer/MainContainerModule.swift
@@ -16,9 +16,6 @@ class MainContainerModule: ViperModuleProtocol {
     }
     
     func assemble() -> (view: AnyView, presenter: MainContainerPresenter) {
-        guard let userState = userState else {
-            fatalError("userState is not initialised")
-        }
         let interactor = MainContainerInteractor(userState: userState)
         let presenter = MainContainerPresenter(userState: userState)
         let router = MainContainerRouter(userState: userState)

--- a/Challo/Challo/Modules/MainContainer/MainContainerPresenter.swift
+++ b/Challo/Challo/Modules/MainContainer/MainContainerPresenter.swift
@@ -15,7 +15,7 @@ class MainContainerPresenter: PresenterProtocol, ObservableObject {
 
     var interactor: MainContainerInteractor!
     var router: MainContainerRouter?
-    unowned let userState: UserStateProtocol!
+    let userState: UserStateProtocol
     
     private var cancellables: Set<AnyCancellable> = []
 

--- a/Challo/Challo/Modules/Settings/SettingsInteractor.swift
+++ b/Challo/Challo/Modules/Settings/SettingsInteractor.swift
@@ -7,7 +7,7 @@
 
 class SettingsInteractor: InteractorProtocol {
     weak var presenter: SettingsPresenter!
-    private weak var userState: UserStateProtocol!
+    let userState: UserStateProtocol
 
     init(userState: UserStateProtocol) {
         self.userState = userState

--- a/Challo/Challo/Modules/Settings/SettingsModule.swift
+++ b/Challo/Challo/Modules/Settings/SettingsModule.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 final class SettingsModule: ViperModuleProtocol {
     
-    weak var userState: UserStateProtocol?
+    let userState: UserStateProtocol
     
     init(userState: UserStateProtocol) {
         self.userState = userState

--- a/Challo/Challo/Modules/Settings/SettingsModule.swift
+++ b/Challo/Challo/Modules/Settings/SettingsModule.swift
@@ -15,9 +15,6 @@ final class SettingsModule: ViperModuleProtocol {
         self.userState = userState
     }
     func assemble() -> (view: AnyView, presenter: SettingsPresenter) {
-        guard let userState = userState else {
-            fatalError("userState is nil in SettingsModule")
-        }
         let presenter = SettingsPresenter(userState: userState)
         let interactor = SettingsInteractor(userState: userState)
         let router = SettingsRouter(userState: userState)

--- a/Challo/Challo/Modules/Settings/SettingsPresenter.swift
+++ b/Challo/Challo/Modules/Settings/SettingsPresenter.swift
@@ -11,7 +11,7 @@ import Combine
 class SettingsPresenter: PresenterProtocol, ObservableObject {
     var router: SettingsRouter?
     var interactor: SettingsInteractor!
-    let userState: UserStateProtocol!
+    let userState: UserStateProtocol
     
     @Published var settingOptionViews: [SettingsListElement<AnyView>] = []
     var loggedInSettingOptions: [SettingsListElement<AnyView>] = []


### PR DESCRIPTION
Weak/unowned refs are only to avoid reference cycles. However, modules only have a one-way association to `userState` and we do not have to worry about reference cycles.
